### PR TITLE
fix: Latest chalk requires ESM modules, used fixed version instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/dracupid/npm-up",
   "dependencies": {
-    "chalk": "latest",
+    "chalk": "^4.1.0",
     "cli-spinner": "^0.2.10",
     "commander": "^2.19.0",
     "global-npm": "latest",


### PR DESCRIPTION
The latest version of [chalk](https://www.npmjs.com/package/chalk) has a [breaking change](https://github.com/chalk/chalk/releases/tag/v5.0.0) requiring ESM modules instead of CJS.

This can be resolved by fixing Chalk to version 4.x in your package.json.

Also see [issue #7 in global-npm](https://github.com/dracupid/global-npm/issues/8) which causes faults in npm@^8.3.0 causing this module to break.